### PR TITLE
Make Serde skip values that are None.

### DIFF
--- a/everestrs/everestrs-build/jinja/client.jinja2
+++ b/everestrs/everestrs-build/jinja/client.jinja2
@@ -1,7 +1,7 @@
 /// {{trait.description | replace("\n", " ")}}
 pub(crate) trait {{trait.name | title}}ClientSubscriber: Sync + Send {
 {% for var in trait.vars %}
-   fn on_{{ var.name | snake }}(&self, publishers: &ModulePublisher, value: {{ var.data_type }});
+   fn on_{{ var.name | snake }}(&self, publishers: &ModulePublisher, value: {{ var.data_type.name }});
 {% endfor %}
 }
 
@@ -14,7 +14,7 @@ fn dispatch_variable_to_{{ trait.name | snake }}(
    match name {
 {%- for var in trait.vars %}
    "{{ var.name }}" => {
-   let v: {{ var.data_type }} = ::serde_json::from_value(value)
+   let v: {{ var.data_type.name }} = ::serde_json::from_value(value)
          .map_err(|_| ::everestrs::Error::InvalidArgument("{{ var.name }}"))?;
          client_subscriber.on_{{ var.name }}(publishers, v);
                 Ok(())
@@ -43,10 +43,10 @@ impl {{trait.name | title }}ClientPublisher {
    {% endif %}
    pub(crate) fn {{cmd.name | snake}}(&self,
    {%- for arg in cmd.arguments %}
-      {{arg.name | snake }}: {{arg.data_type}},
+      {{arg.name | snake }}: {{arg.data_type.name}},
    {%- endfor %}
    ) -> ::everestrs::Result<{%- if cmd.result -%}
-      {{cmd.result.data_type}}
+      {{cmd.result.data_type.name}}
    {%- else -%}
       ()
    {%- endif -%}

--- a/everestrs/everestrs-build/jinja/config.jinja2
+++ b/everestrs/everestrs-build/jinja/config.jinja2
@@ -4,7 +4,7 @@
 pub(crate) struct {{ p_config.name | title }}Config {
     {% for config in p_config.config %}
     /// {{ config.description }}
-    pub(crate) {{ config.name }}: {{ config.data_type }},
+    pub(crate) {{ config.name }}: {{ config.data_type.name }},
     {% endfor %}
 }
 {% endfor %}
@@ -15,7 +15,7 @@ pub(crate) struct {{ p_config.name | title }}Config {
 pub(crate) struct ModuleConfig {
     {% for config in module_config %}
     /// {{ config.description }}
-    pub(crate) {{ config.name }}: {{ config.data_type }},
+    pub(crate) {{ config.name }}: {{ config.data_type.name }},
     {% endfor %}
 
     {% for p_config in provided_config %}

--- a/everestrs/everestrs-build/jinja/service.jinja2
+++ b/everestrs/everestrs-build/jinja/service.jinja2
@@ -13,10 +13,10 @@ pub(crate) trait {{trait.name | title}}ServiceSubscriber: Sync + Send {
    fn {{cmd.name}}(&self,
       publishers: &ModulePublisher,
    {%- for arg in cmd.arguments %}
-      {{arg.name | snake }}: {{arg.data_type}},
+      {{arg.name | snake }}: {{arg.data_type.name}},
    {%- endfor %}
    ) -> ::everestrs::Result<{%- if cmd.result -%}
-      {{cmd.result.data_type}}
+      {{cmd.result.data_type.name}}
    {%- else -%}
       ()
    {%- endif -%}>;
@@ -33,7 +33,7 @@ fn dispatch_command_to_{{ trait.name | snake }}(
 {%- for cmd in trait.cmds %}
    "{{ cmd.name }}" => {
 {%- for arg in cmd.arguments %}
-      let {{ arg.name | snake }}: {{ arg.data_type }} = ::serde_json::from_value(
+      let {{ arg.name | snake }}: {{ arg.data_type.name }} = ::serde_json::from_value(
          parameters.remove("{{ arg.name }}")
             .ok_or(::everestrs::Error::MissingArgument("{{ arg.name }}"))?,
           )
@@ -59,7 +59,7 @@ pub(crate) struct {{trait.name | title }}ServicePublisher {
 
 impl {{trait.name | title }}ServicePublisher {
 {% for var in trait.vars %}
-   pub(crate) fn {{ var.name | snake }}(&self, value: {{ var.data_type }}) -> ::everestrs::Result<()> {
+   pub(crate) fn {{ var.name | snake }}(&self, value: {{ var.data_type.name }}) -> ::everestrs::Result<()> {
       self.runtime.publish_variable(self.implementation_id, "{{ var.name }}", &value);
       Ok(())
    }

--- a/everestrs/everestrs-build/jinja/types.jinja2
+++ b/everestrs/everestrs-build/jinja/types.jinja2
@@ -9,8 +9,8 @@ pub mod {{ name }} {
 pub struct {{ object.name }} {
 {% for p in object.properties %}
 /// {{ p.description | replace("\n", " ") }}
-#[serde(rename="{{ p.name }}")]
-pub {{ p.name | snake }}: {{ p.data_type }},
+#[serde(rename="{{ p.name }}"{% if p.data_type.extra_serde_annotations %},{{ p.data_type.extra_serde_annotations | join(",") }}{% endif %})]
+pub {{ p.name | snake }}: {{ p.data_type.name }},
 {% endfor %}
 }
 {% endfor %}

--- a/everestrs/everestrs-build/src/codegen.rs
+++ b/everestrs/everestrs-build/src/codegen.rs
@@ -178,10 +178,16 @@ fn as_typename(arg: &Argument, type_refs: &mut BTreeSet<TypeRef>) -> Result<Stri
 }
 
 #[derive(Debug, Clone, Serialize)]
+struct DataTypeContext {
+    name: String,
+    extra_serde_annotations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
 struct ArgumentContext {
     name: String,
     description: Option<String>,
-    data_type: String,
+    data_type: DataTypeContext,
 }
 
 impl ArgumentContext {
@@ -193,7 +199,10 @@ impl ArgumentContext {
         Ok(ArgumentContext {
             name,
             description: var.description.clone(),
-            data_type: as_typename(&var.arg, type_refs)?,
+            data_type: DataTypeContext {
+                name: as_typename(&var.arg, type_refs)?,
+                extra_serde_annotations: Vec::new(),
+            },
         })
     }
 }
@@ -307,9 +316,12 @@ fn type_context_from_ref(
         Single(Object(args)) => {
             let mut properties = Vec::new();
             for (name, var) in &args.properties {
+                let mut extra_serde_annotations = Vec::new();
                 let data_type = {
                     let d = as_typename(&var.arg, type_refs)?;
                     if !args.required.contains(name) {
+                        extra_serde_annotations
+                            .push("skip_serializing_if = \"Option::is_none\"".to_string());
                         format!("Option<{}>", d)
                     } else {
                         d
@@ -318,7 +330,10 @@ fn type_context_from_ref(
                 properties.push(ArgumentContext {
                     name: name.clone(),
                     description: var.description.clone(),
-                    data_type,
+                    data_type: DataTypeContext {
+                        name: data_type,
+                        extra_serde_annotations,
+                    },
                 });
             }
             Ok(TypeContext::Object(ObjectTypeContext {
@@ -410,7 +425,10 @@ fn emit_config(config: BTreeMap<String, ConfigEntry>) -> Vec<ArgumentContext> {
             ConfigEnum::Boolean { default: _ } => ArgumentContext {
                 name: k,
                 description: v.description,
-                data_type: "bool".to_string(),
+                data_type: DataTypeContext {
+                    name: "bool".to_string(),
+                    extra_serde_annotations: Vec::new(),
+                },
             },
             ConfigEnum::Integer {
                 default: _,
@@ -419,7 +437,10 @@ fn emit_config(config: BTreeMap<String, ConfigEntry>) -> Vec<ArgumentContext> {
             } => ArgumentContext {
                 name: k,
                 description: v.description,
-                data_type: "i64".to_string(),
+                data_type: DataTypeContext {
+                    name: "i64".to_string(),
+                    extra_serde_annotations: Vec::new(),
+                },
             },
             ConfigEnum::Number {
                 default: _,
@@ -428,7 +449,10 @@ fn emit_config(config: BTreeMap<String, ConfigEntry>) -> Vec<ArgumentContext> {
             } => ArgumentContext {
                 name: k,
                 description: v.description,
-                data_type: "f64".to_string(),
+                data_type: DataTypeContext {
+                    name: "f64".to_string(),
+                    extra_serde_annotations: Vec::new(),
+                },
             },
             ConfigEnum::String {
                 default: _,
@@ -437,7 +461,10 @@ fn emit_config(config: BTreeMap<String, ConfigEntry>) -> Vec<ArgumentContext> {
             } => ArgumentContext {
                 name: k,
                 description: v.description,
-                data_type: "String".to_string(),
+                data_type: DataTypeContext {
+                    name: "String".to_string(),
+                    extra_serde_annotations: Vec::new(),
+                },
             },
         })
         .collect::<Vec<_>>()


### PR DESCRIPTION
The C++ nlohman json parser is confused seeing null values instead of skipping values. This changes codegen so that empty options are skipped instead of send as `null`.